### PR TITLE
[bbcode] Spoiler

### DIFF
--- a/modules/forum/controllers/index.php
+++ b/modules/forum/controllers/index.php
@@ -197,6 +197,8 @@ class m_forum_c_index extends Controller_Module
 				->breadcrumb()
 				->js('neofrag.delete');
 		
+		$this->js('bbcode');
+		
 		$last_message_read = NULL;
 		
 		$is_last_page = $nb_messages <= $this->pagination->get_items_per_page() || $this->pagination->get_page() == ceil($nb_messages / $this->pagination->get_items_per_page());

--- a/modules/forum/js/bbcode.js
+++ b/modules/forum/js/bbcode.js
@@ -1,0 +1,5 @@
+$(function(){
+	$(".spoiler-trigger").click(function() {
+		$(this).parent().next().collapse('toggle');
+	});	
+});

--- a/neofrag/libraries/bbcode.php
+++ b/neofrag/libraries/bbcode.php
@@ -39,7 +39,9 @@ class BBCode extends Library
 		'\[(left|center|right)\](.*?)\[/\1\]'               => '<div style="text-align: \1;">\2</div>',
 		'\[quote\](.*?)\[/quote\]'                          => '<blockquote>\1</blockquote>',
 		'\[code\](.*?)\[/code\]'                            => '<code>\1</code>',
-		'\[(table)\](.*?)\[/\1\]'                           => '<\1 class="table table-bordered">\2</\1>'
+		'\[(table)\](.*?)\[/\1\]'                           => '<\1 class="table table-bordered">\2</\1>',
+		'\[spoiler\](.*?)\[/spoiler\]'                      => '<div class="panel panel-default"><div class="panel-heading"><button type="button" class="btn btn-default btn-xs spoiler-trigger" data-toggle="collapse">Spoiler</button></div><div class="panel-collapse collapse out"><div class="panel-body"><p>\1</p></div></div></div>',
+		'\[hide=(.*?)\](.*?)\[/hide\]'                        => '<div class="panel panel-default"><div class="panel-heading"><button type="button" class="btn btn-default btn-xs spoiler-trigger" data-toggle="collapse">\1</button></div><div class="panel-collapse collapse out"><div class="panel-body"><p>\2</p></div></div></div>'
 	);
 
 	public function bbcode2html($output)

--- a/neofrag/libraries/bbcode.php
+++ b/neofrag/libraries/bbcode.php
@@ -41,7 +41,7 @@ class BBCode extends Library
 		'\[code\](.*?)\[/code\]'                            => '<code>\1</code>',
 		'\[(table)\](.*?)\[/\1\]'                           => '<\1 class="table table-bordered">\2</\1>',
 		'\[spoiler\](.*?)\[/spoiler\]'                      => '<div class="panel panel-default"><div class="panel-heading"><button type="button" class="btn btn-default btn-xs spoiler-trigger" data-toggle="collapse">Spoiler</button></div><div class="panel-collapse collapse out"><div class="panel-body"><p>\1</p></div></div></div>',
-		'\[hide=(.*?)\](.*?)\[/hide\]'                        => '<div class="panel panel-default"><div class="panel-heading"><button type="button" class="btn btn-default btn-xs spoiler-trigger" data-toggle="collapse">\1</button></div><div class="panel-collapse collapse out"><div class="panel-body"><p>\2</p></div></div></div>'
+		'\[hide=(.*?)\](.*?)\[/hide\]'                      => '<div class="panel panel-default"><div class="panel-heading"><button type="button" class="btn btn-default btn-xs spoiler-trigger" data-toggle="collapse">\1</button></div><div class="panel-collapse collapse out"><div class="panel-body"><p>\2</p></div></div></div>'
 	);
 
 	public function bbcode2html($output)


### PR DESCRIPTION
Bonjour,
### Pour résumer

Ajout de la balise bbcode spoiler et hide.
### En détail

Conformément à la page wikipédia [bbcode](https://fr.wikipedia.org/wiki/BBCode) les balises s'utilisent de la façon suivante:
- Texte caché apparaissant quand on clique sur « Spoiler » :
  - [spoiler]Texte[/spoiler]
- Texte caché apparaissant quand on clique sur une phrase ou un mot : 
  - [hide="Titre du spoiler"]Texte[/hide]

Note : Pourquoi ne les ont ils pas appelé tous les deux spoiler ou hide?

Concernant l'intégration dans l'éditeur wysibb cela semble plus compliqué. Il faudrait modifier l'appel de celui-ci a de nombreux endroits dans le controller/index.php L 499. CF [doc](http://www.wysibb.com/docs/p1.html). Le problème c'est de devoir surcharger l'option "buttons" ce qui pose problème en cas de modification de la lib. On ne peut pas juste ajouter un bouton.

Pour la modification de modules/forum/controllers/index.php, pour une raison que je ne comprend pas en chaînant avec le reste juste avant cela ne fonctionne pas. Cela fonctionne cependant si je le met entre le title et breadcrumb. Si vous savez m'expliquer pourquoi?

Cordialement, Zehir
