### PR TITLE
Update db.php

### DIFF
--- a/neofrag/core/db.php
+++ b/neofrag/core/db.php
@@ -189,7 +189,7 @@ class Db extends Core
 				'operator' => $operator
 			];
 			
-			if (func_num_args() == 1)
+			if (func_num_args() == 1 || empty($value))
 			{
 				unset($where->value);
 			}


### PR DESCRIPTION
If a user create a widget/module that need a "OR" and not an "AND" for the next part of the query, it can be accessed without entering a value. 

e.g. :
if the user use this syntax : $this->db->where('my column = my value', '', 'OR');