### PR TITLE
add Docker & Docker-Compose files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM bylexus/apache-php7
+MAINTAINER BuRner <burner@live.be>
+
+RUN apt-get update && \
+    apt-get install --no-install-recommends -y \
+	php7.0-intl \
+	php7.0-curl \
+	&& rm -rf /var/lib/apt/lists/*

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,26 @@
+version: '3'
+
+services:
+  database:
+    image: mysql:5.7
+    command: --sql_mode="STRICT_ALL_TABLES,ERROR_FOR_DIVISION_BY_ZERO,NO_ZERO_DATE,NO_ZERO_IN_DATE,NO_AUTO_CREATE_USER"
+    environment:
+      MYSQL_ALLOW_EMPTY_PASSWORD: 'yes'
+      MYSQL_DATABASE: neofrag
+    ports:
+      - "3306:3306"
+    volumes:
+      - mysql-datavolume:/var/lib/mysql
+      - ./DATABASE.sql:/docker-entrypoint-initdb.d/DATABASE.sql
+  web:
+    build: .
+    depends_on:
+      - database
+    ports: 
+      - "80:80"
+    volumes:
+      - ./:/var/www
+    environment:
+      - PHP_ERROR_REPORTING="E_ALL & ~E_STRICT"
+volumes:
+  mysql-datavolume:


### PR DESCRIPTION
Dockerfile basé sur une image existante. Elle contient probablement des packages inutiles et alourdi l'image finale. Il y a donc moyen de l'optimiser mais pour l'instant cela fonctionne bien de cette manière.

Le Dockerfile n'est pas utilisable seul puisqu'il ne fait qu'installer un debian avec apache et php7 ainsi que les extensions nécessaires à NeoFrag. Il faut utiliser le fichier docker-compose, qui lui utilise les fichiers du répertoire courant pour les ajouter dans le répertoire /var/www du container docker. Il démarre également un container MySQL pour la base de données et initialise la base de données au démarrage du container.